### PR TITLE
Update xray.js

### DIFF
--- a/web/assets/js/model/xray.js
+++ b/web/assets/js/model/xray.js
@@ -1336,7 +1336,7 @@ class Inbound extends XrayCommonClass {
             params.set("security", "none");
         }
 
-        const link = `vless://${uuid}@${address}:${port}`;
+        const link = `vless://${uuid}@${this.stream.tls.sni}:${port}`;
         const url = new URL(link);
         for (const [key, value] of params) {
             url.searchParams.set(key, value)


### PR DESCRIPTION
If you want to have different SNI for different Inbounds, using different domain names and different certificates, the link  uuid@address:port won't work, instead you must use the SNI of individual inbounds